### PR TITLE
20180102 marcoct densescoring

### DIFF
--- a/src/dict_trace.jl
+++ b/src/dict_trace.jl
@@ -20,6 +20,7 @@ mutable struct DictTrace <: Trace
 
     # key is a single element of an address (called `addr_first` in the code)
     subtraces::Dict{Any, Trace}
+    scores::Dict{Any,Any}
 
     # the value for address ()
     has_empty_address_value::Bool
@@ -28,8 +29,9 @@ end
 
 function DictTrace()
     subtraces = Dict{Any, Trace}()
+    scores = Dict{Any, Any}()
     empty_address_value = nothing
-    DictTrace(subtraces, false, empty_address_value)
+    DictTrace(subtraces, scores, false, empty_address_value)
 end
 
 
@@ -150,8 +152,18 @@ function Base.print(io::IO, trace::DictTrace)
     println(io, ")")
 end
 
+function set_score!(trace::DictTrace, addr_first, value)
+    trace.scores[addr_first] = value
+end
+
+function get_score(trace::DictTrace, addr_first)
+    return trace.scores[addr_first]
+end
+
 export DictTrace
 export has_subtrace
 export get_subtrace
 export set_subtrace!
 export delete_subtrace!
+export set_score!
+export get_score

--- a/src/dict_trace.jl
+++ b/src/dict_trace.jl
@@ -20,7 +20,6 @@ mutable struct DictTrace <: Trace
 
     # key is a single element of an address (called `addr_first` in the code)
     subtraces::Dict{Any, Trace}
-    scores::Dict{Any,Any}
 
     # the value for address ()
     has_empty_address_value::Bool
@@ -29,9 +28,8 @@ end
 
 function DictTrace()
     subtraces = Dict{Any, Trace}()
-    scores = Dict{Any, Any}()
     empty_address_value = nothing
-    DictTrace(subtraces, scores, false, empty_address_value)
+    DictTrace(subtraces, false, empty_address_value)
 end
 
 
@@ -152,18 +150,8 @@ function Base.print(io::IO, trace::DictTrace)
     println(io, ")")
 end
 
-function set_score!(trace::DictTrace, addr_first, value)
-    trace.scores[addr_first] = value
-end
-
-function get_score(trace::DictTrace, addr_first)
-    return trace.scores[addr_first]
-end
-
 export DictTrace
 export has_subtrace
 export get_subtrace
 export set_subtrace!
 export delete_subtrace!
-export set_score!
-export get_score

--- a/src/primitives/niwn.jl
+++ b/src/primitives/niwn.jl
@@ -20,7 +20,6 @@ struct NIWParams
     k::Float64
 
     # degrees of freedom for the inverse Wishart distribution on covariance
-    # corresponds to 'mu' in NIGNParams
 	m::Float64
 
     # scale parameter for the inverse Wishart distribution on covariance
@@ -52,6 +51,9 @@ mutable struct NIWNState
         new(0, zeros(dimension), zeros(dimension, dimension))
     end
 end
+
+Base.isempty(state::NIWNState) = (state.n == 0)
+
 function incorporate!(state::NIWNState, x::Vector{Float64})
     state.n += 1
     state.x_total += x
@@ -204,6 +206,7 @@ Base.getindex(t::NIWNTrace{A}, addr_element::A) where {A} = t[(addr_element,)]
 
 Base.setindex!(t::NIWNTrace{A}, value::Vector{Float64}, addr_element::A) where {A} = begin t[(addr_element,)] = value end
 
+get_state(trace::NIWNTrace) = trace.state
 
 struct NIWNGenerator{A} <: Generator{NIWNTrace{A}}
     dim::Int
@@ -306,4 +309,5 @@ function simulate!(::NIWNGenerator{A}, args::Tuple{Any,NIWParams,Bool}, outputs,
 end
 
 export NIWNTrace
+export get_state
 export NIWNGenerator

--- a/src/primitives/simple.jl
+++ b/src/primitives/simple.jl
@@ -18,6 +18,26 @@ register_primitive(:flip, Flip)
 
 
 """
+Bernoulli generator with log probability argument, with singleton `logflip`
+# TODO this has numerical issues in one of the two directions: it should be
+# removed in favor of a logit version.
+
+    generate!(logflip, (log_prob,), trace::AtomicTrace{Bool})
+
+    logflip(prob)
+
+Score is not differentiable with respect to `logprob`
+"""
+struct LogFlip <: AssessableAtomicGenerator{Bool} end
+
+Base.rand(::LogFlip, logprob::Float64) = log(rand()) < logprob
+Gen.logpdf(::LogFlip, value::Bool, logprob::Float64) = value ? logprob : log1p(-exp(logprob))
+
+register_primitive(:logflip, LogFlip)
+
+
+
+"""
 Beta generator, with singleton `beta`.
 
     generate!(beta, (a, b), trace::AtomicTrace{Float64})

--- a/src/probabilistic_program.jl
+++ b/src/probabilistic_program.jl
@@ -55,13 +55,14 @@ struct ProbabilisticProgramRuntimeState
     trace::DictTrace
     outputs
     conditions
-    score::Score
+    score::Score # output score
+    internal_score::Score
     aliases_by_subtrace_address::Dict
     all_aliases::Set
 end
 
 function ProbabilisticProgramRuntimeState(trace::DictTrace, outputs, conditions)
-    ProbabilisticProgramRuntimeState(trace, outputs, conditions, Score(), Dict(), Set())
+    ProbabilisticProgramRuntimeState(trace, outputs, conditions, Score(), Score(), Dict(), Set())
 end
 
 function add_alias!(state::ProbabilisticProgramRuntimeState, alias, addr::Tuple)
@@ -201,10 +202,10 @@ function tagged!(runtime_state::ProbabilisticProgramRuntimeState,
     increment!(runtime_state.score, increment)
     set_subtrace!(runtime_state.trace, addr_first, subtrace)
 
-    # score every atomic assessable generator
+    # score every atomic assessable generator that is not an output (i.e. every internal choice)
     # NOTE: HACK because it only applies to assessable atomic generators
-    if isa(generator, AssessableAtomicGenerator)
-        set_score!(runtime_state.trace, addr_first, logpdf(generator, subtrace[()], args...))
+    if isa(generator, AssessableAtomicGenerator) && !(() in sub_outputs)
+        increment!(runtime_state.internal_score, logpdf(generator, subtrace[()], args...))
     end
 
     # copy values from subtrace to aliases
@@ -307,7 +308,10 @@ function _simulate_or_regenerate!(p::ProbabilisticProgram, args::Tuple, outputs,
         runtime_state = ProbabilisticProgramRuntimeState(trace, outputs, conditions)
         value = p.program(runtime_state, method, args...)
         trace[()] = value
-        return (get(runtime_state.score), value)
+        # TODO breaking interface change: put value first, we want scores at
+        # the end to maintain backward compatability if we want to add more
+        # return values, like we added 'internal score'
+        return (get(runtime_state.score), value, get(runtime_state.internal_score))
     end
 end
 

--- a/src/probabilistic_program.jl
+++ b/src/probabilistic_program.jl
@@ -197,8 +197,15 @@ function tagged!(runtime_state::ProbabilisticProgramRuntimeState,
         # there are no other methods
         @assert false
     end
+
     increment!(runtime_state.score, increment)
     set_subtrace!(runtime_state.trace, addr_first, subtrace)
+
+    # score every atomic assessable generator
+    # NOTE: HACK because it only applies to assessable atomic generators
+    if isa(generator, AssessableAtomicGenerator)
+        set_score!(runtime_state.trace, addr_first, logpdf(generator, subtrace[()], args...))
+    end
 
     # copy values from subtrace to aliases
     for (addr_rest, alias) in get_aliases(runtime_state, addr_first)

--- a/test/primitives/simple.jl
+++ b/test/primitives/simple.jl
@@ -5,6 +5,11 @@ import Distributions
     @test isapprox(logpdf(Flip(), false, 0.1), log(0.9))
 end
 
+@testset "logflip" begin
+    @test isapprox(logpdf(LogFlip(), true, log(0.1)), log(0.1))
+    @test isapprox(logpdf(LogFlip(), false, log(0.1)), log(0.9))
+end
+
 @testset "beta" begin
 
     # test against Distributions.Beta since we re-implement the density


### PR DESCRIPTION
Mainly adds a 'dense scoring' feature, which scores all internal random choices in a probabilistic program, and stores this score in a separate `internal_score` value in the program state. This feature was needed for a simple version of backpropagation through stochastic nodes for https://github.com/probcomp/pps2018-proposals.